### PR TITLE
Update atomic_queue to v1.6.9

### DIFF
--- a/external/atomic_queue/include/atomic_queue/atomic_queue_mutex.h
+++ b/external/atomic_queue/include/atomic_queue/atomic_queue_mutex.h
@@ -1,0 +1,92 @@
+/* -*- mode: c++; c-basic-offset: 4; indent-tabs-mode: nil; tab-width: 4 -*- */
+#ifndef ATOMIC_QUEUE_ATOMIC_QUEUE_SPIN_LOCK_H_INCLUDED
+#define ATOMIC_QUEUE_ATOMIC_QUEUE_SPIN_LOCK_H_INCLUDED
+
+// Copyright (c) 2019 Maxim Egorushkin. MIT License. See the full licence in file LICENSE.
+
+#include "atomic_queue.h"
+#include "spinlock.h"
+
+#include <mutex>
+#include <cassert>
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace atomic_queue {
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template<class M>
+struct ScopedLockType {
+    using type = typename M::scoped_lock;
+};
+
+template<>
+struct ScopedLockType<std::mutex> {
+    using type = std::unique_lock<std::mutex>;
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template<class T, class Mutex, unsigned SIZE, bool MINIMIZE_CONTENTION>
+class AtomicQueueMutexT {
+    static constexpr unsigned size_ = MINIMIZE_CONTENTION ? details::round_up_to_power_of_2(SIZE) : SIZE;
+
+    Mutex mutex_;
+    alignas(CACHE_LINE_SIZE) unsigned head_ = 0;
+    alignas(CACHE_LINE_SIZE) unsigned tail_ = 0;
+    alignas(CACHE_LINE_SIZE) T q_[size_] = {};
+
+    static constexpr int SHUFFLE_BITS = details::GetIndexShuffleBits<MINIMIZE_CONTENTION, size_, CACHE_LINE_SIZE / sizeof(T)>::value;
+
+    using ScopedLock = typename ScopedLockType<Mutex>::type;
+
+public:
+    using value_type = T;
+
+    template<class U>
+    bool try_push(U&& element) noexcept {
+        ScopedLock lock(mutex_);
+        if(ATOMIC_QUEUE_LIKELY(head_ - tail_ < size_)) {
+            q_[details::remap_index<SHUFFLE_BITS>(head_ % size_)] = std::forward<U>(element);
+            ++head_;
+            return true;
+        }
+        return false;
+    }
+
+    bool try_pop(T& element) noexcept {
+        ScopedLock lock(mutex_);
+        if(ATOMIC_QUEUE_LIKELY(head_ != tail_)) {
+            element = std::move(q_[details::remap_index<SHUFFLE_BITS>(tail_ % size_)]);
+            ++tail_;
+            return true;
+        }
+        return false;
+    }
+
+    bool was_empty() const noexcept {
+        return static_cast<int>(head_ - tail_) <= 0;
+    }
+
+    bool was_full() const noexcept {
+        return static_cast<int>(head_ - tail_) >= static_cast<int>(size_);
+    }
+};
+
+template<class T, unsigned SIZE, class Mutex, bool MINIMIZE_CONTENTION = true>
+using AtomicQueueMutex = AtomicQueueMutexT<T, Mutex, SIZE, MINIMIZE_CONTENTION>;
+
+template<class T, unsigned SIZE, bool MINIMIZE_CONTENTION = true>
+using AtomicQueueSpinlock = AtomicQueueMutexT<T, Spinlock, SIZE, MINIMIZE_CONTENTION>;
+
+// template<class T, unsigned SIZE, bool MINIMIZE_CONTENTION = true>
+// using AtomicQueueSpinlockHle = AtomicQueueMutexT<T, SpinlockHle, SIZE, MINIMIZE_CONTENTION>;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+} // namespace atomic_queue
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#endif // ATOMIC_QUEUE_ATOMIC_QUEUE_SPIN_LOCK_H_INCLUDED

--- a/external/atomic_queue/include/atomic_queue/barrier.h
+++ b/external/atomic_queue/include/atomic_queue/barrier.h
@@ -1,0 +1,38 @@
+/* -*- mode: c++; c-basic-offset: 4; indent-tabs-mode: nil; tab-width: 4 -*- */
+#ifndef BARRIER_H_INCLUDED
+#define BARRIER_H_INCLUDED
+
+// Copyright (c) 2019 Maxim Egorushkin. MIT License. See the full licence in file LICENSE.
+
+#include "defs.h"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace atomic_queue {
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+class Barrier {
+    std::atomic<unsigned> counter_ = {};
+
+public:
+    void wait() noexcept {
+        counter_.fetch_add(1, std::memory_order_acquire);
+        while(counter_.load(std::memory_order_relaxed))
+            spin_loop_pause();
+    }
+
+    void release(unsigned expected_counter) noexcept {
+        while(expected_counter != counter_.load(std::memory_order_relaxed))
+            spin_loop_pause();
+        counter_.store(0, std::memory_order_release);
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+} // namespace atomic_queue
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#endif // BARRIER_H_INCLUDED

--- a/external/atomic_queue/include/atomic_queue/defs.h
+++ b/external/atomic_queue/include/atomic_queue/defs.h
@@ -56,6 +56,14 @@ static inline void spin_loop_pause() noexcept {
     asm volatile (".insn i 0x0F, 0, x0, x0, 0x010");
 }
 } // namespace atomic_queue
+#elif defined(__loongarch__)
+namespace atomic_queue {
+constexpr int CACHE_LINE_SIZE = 64;
+static inline void spin_loop_pause() noexcept
+{
+    asm volatile("nop \n nop \n nop \n nop \n nop \n nop \n nop \n nop");
+}
+} // namespace atomic_queue
 #else
 #ifdef _MSC_VER
 #pragma message("Unknown CPU architecture. Using L1 cache line size of 64 bytes and no spinloop pause instruction.")

--- a/external/atomic_queue/include/atomic_queue/spinlock.h
+++ b/external/atomic_queue/include/atomic_queue/spinlock.h
@@ -1,0 +1,203 @@
+/* -*- mode: c++; c-basic-offset: 4; indent-tabs-mode: nil; tab-width: 4 -*- */
+#ifndef ATOMIC_QUEUE_SPIN_LOCK_H_INCLUDED
+#define ATOMIC_QUEUE_SPIN_LOCK_H_INCLUDED
+
+// Copyright (c) 2019 Maxim Egorushkin. MIT License. See the full licence in file LICENSE.
+
+#include "defs.h"
+
+#include <atomic>
+#include <cstdlib>
+#include <mutex>
+
+#include <pthread.h>
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace atomic_queue {
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+class Spinlock {
+    pthread_spinlock_t s_;
+
+public:
+    using scoped_lock = std::lock_guard<Spinlock>;
+
+    Spinlock() noexcept {
+        if(ATOMIC_QUEUE_UNLIKELY(::pthread_spin_init(&s_, 0)))
+            std::abort();
+    }
+
+    Spinlock(Spinlock const&) = delete;
+    Spinlock& operator=(Spinlock const&) = delete;
+
+    ~Spinlock() noexcept {
+        ::pthread_spin_destroy(&s_);
+    }
+
+    void lock() noexcept {
+        if(ATOMIC_QUEUE_UNLIKELY(::pthread_spin_lock(&s_)))
+            std::abort();
+    }
+
+    void unlock() noexcept {
+        if(ATOMIC_QUEUE_UNLIKELY(::pthread_spin_unlock(&s_)))
+            std::abort();
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+class TicketSpinlock {
+    alignas(CACHE_LINE_SIZE) std::atomic<unsigned> ticket_{0};
+    alignas(CACHE_LINE_SIZE) std::atomic<unsigned> next_{0};
+
+public:
+    class LockGuard {
+        TicketSpinlock* const m_;
+        unsigned const ticket_;
+    public:
+        LockGuard(TicketSpinlock& m) noexcept
+            : m_(&m)
+            , ticket_(m.lock())
+        {}
+
+        LockGuard(LockGuard const&) = delete;
+        LockGuard& operator=(LockGuard const&) = delete;
+
+        ~LockGuard() noexcept {
+            m_->unlock(ticket_);
+        }
+    };
+
+    using scoped_lock = LockGuard;
+
+    TicketSpinlock() noexcept = default;
+    TicketSpinlock(TicketSpinlock const&) = delete;
+    TicketSpinlock& operator=(TicketSpinlock const&) = delete;
+
+    ATOMIC_QUEUE_NOINLINE unsigned lock() noexcept {
+        auto ticket = ticket_.fetch_add(1, std::memory_order_relaxed);
+        for(;;) {
+            auto position = ticket - next_.load(std::memory_order_acquire);
+            if(ATOMIC_QUEUE_LIKELY(!position))
+                break;
+            do
+                spin_loop_pause();
+            while(--position);
+        }
+        return ticket;
+    }
+
+    void unlock() noexcept {
+        unlock(next_.load(std::memory_order_relaxed) + 1);
+    }
+
+    void unlock(unsigned ticket) noexcept {
+        next_.store(ticket + 1, std::memory_order_release);
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+class UnfairSpinlock {
+    std::atomic<unsigned> lock_{0};
+
+public:
+    using scoped_lock = std::lock_guard<UnfairSpinlock>;
+
+    UnfairSpinlock(UnfairSpinlock const&) = delete;
+    UnfairSpinlock& operator=(UnfairSpinlock const&) = delete;
+
+    void lock() noexcept {
+        for(;;) {
+            if(!lock_.load(std::memory_order_relaxed) && !lock_.exchange(1, std::memory_order_acquire))
+                return;
+            spin_loop_pause();
+        }
+    }
+
+    void unlock() noexcept {
+        lock_.store(0, std::memory_order_release);
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// class SpinlockHle {
+//     int lock_ = 0;
+
+// #ifdef __gcc__
+//     static constexpr int HLE_ACQUIRE = __ATOMIC_HLE_ACQUIRE;
+//     static constexpr int HLE_RELEASE = __ATOMIC_HLE_RELEASE;
+// #else
+//     static constexpr int HLE_ACQUIRE = 0;
+//     static constexpr int HLE_RELEASE = 0;
+// #endif
+
+// public:
+//     using scoped_lock = std::lock_guard<Spinlock>;
+
+//     SpinlockHle(SpinlockHle const&) = delete;
+//     SpinlockHle& operator=(SpinlockHle const&) = delete;
+
+//     void lock() noexcept {
+//         for(int expected = 0;
+//             !__atomic_compare_exchange_n(&lock_, &expected, 1, false, __ATOMIC_ACQUIRE | HLE_ACQUIRE, __ATOMIC_RELAXED);
+//             expected = 0)
+//             spin_loop_pause();
+//     }
+
+//     void unlock() noexcept {
+//         __atomic_store_n(&lock_, 0, __ATOMIC_RELEASE | HLE_RELEASE);
+//     }
+// };
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// class AdaptiveMutex {
+//     pthread_mutex_t m_;
+
+// public:
+//     using scoped_lock = std::lock_guard<AdaptiveMutex>;
+
+//     AdaptiveMutex() noexcept {
+//         pthread_mutexattr_t a;
+//         if(ATOMIC_QUEUE_UNLIKELY(::pthread_mutexattr_init(&a)))
+//             std::abort();
+//         if(ATOMIC_QUEUE_UNLIKELY(::pthread_mutexattr_settype(&a, PTHREAD_MUTEX_ADAPTIVE_NP)))
+//             std::abort();
+//         if(ATOMIC_QUEUE_UNLIKELY(::pthread_mutex_init(&m_, &a)))
+//             std::abort();
+//         if(ATOMIC_QUEUE_UNLIKELY(::pthread_mutexattr_destroy(&a)))
+//             std::abort();
+//         m_.__data.__spins = 32767;
+//     }
+
+//     AdaptiveMutex(AdaptiveMutex const&) = delete;
+//     AdaptiveMutex& operator=(AdaptiveMutex const&) = delete;
+
+//     ~AdaptiveMutex() noexcept {
+//         if(ATOMIC_QUEUE_UNLIKELY(::pthread_mutex_destroy(&m_)))
+//             std::abort();
+//     }
+
+//     void lock() noexcept {
+//         if(ATOMIC_QUEUE_UNLIKELY(::pthread_mutex_lock(&m_)))
+//             std::abort();
+//     }
+
+//     void unlock() noexcept {
+//         if(ATOMIC_QUEUE_UNLIKELY(::pthread_mutex_unlock(&m_)))
+//             std::abort();
+//     }
+// };
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+} // namespace atomic_queue
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#endif // ATOMIC_QUEUE_SPIN_LOCK_H_INCLUDED


### PR DESCRIPTION
Fixes a 'include/atomic_queue/atomic_queue.h:403:31: A template argument list is expected after a name prefixed by the template keyword' error when compiling with Xcode 16.3